### PR TITLE
Fixed resin clump missing texture

### DIFF
--- a/common/src/main/resources/assets/minecraft/models/block/resin_clump.json
+++ b/common/src/main/resources/assets/minecraft/models/block/resin_clump.json
@@ -1,8 +1,8 @@
 {
   "ambientocclusion": false,
   "textures": {
-    "particle": "vanillabackport:block/resin_clump",
-    "texture": "vanillabackport:block/resin_clump"
+    "particle": "block/resin_clump",
+    "texture": "block/resin_clump"
   },
   "elements": [
     {   "from": [ 0, 0, 0.1 ],


### PR DESCRIPTION
The namespace in the path to the textures resulted in a missing texture error