### PR TITLE
Fix config not being read for lava chicken disc drops

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/common/LootIntegrations.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/LootIntegrations.java
@@ -67,7 +67,7 @@ public class LootIntegrations implements LootModifier.LootTableModifier {
         }
 
         // CHICKEN JOCKEYS DROP LAVA CHICKEN MUSIC DISC
-        if (path.equals(EntityType.ZOMBIE.getDefaultLootTable())) {
+        if (path.equals(EntityType.ZOMBIE.getDefaultLootTable()) && VanillaBackport.COMMON_CONFIG.hasLavaChickenMusicDisc.get()) {
             context.addPool(
                 LootPool.lootPool()
                     .add(LootItem.lootTableItem(ModItems.MUSIC_DISC_LAVA_CHICKEN.get()))


### PR DESCRIPTION
The same issue also applies to 1.21.1

I couldn't easily test this as the [build.gradle](https://github.com/ItsBlackGear/VanillaBackport/blob/a5c6104422e9a6cf072a6823b9e52f93c8cb0755/build.gradle#L33C1-L33C83) has a hard coded dependency, but this is probably too simple to get wrong anyway