### PR TITLE
Fix config not being read for lava chicken disc

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/common/LootIntegrations.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/LootIntegrations.java
@@ -68,7 +68,7 @@ public class LootIntegrations implements LootModifier.LootTableModifier {
         }
 
         // CHICKEN JOCKEYS DROP LAVA CHICKEN MUSIC DISC
-        if (key.equals(EntityType.ZOMBIE.getDefaultLootTable())) {
+        if (key.equals(EntityType.ZOMBIE.getDefaultLootTable()) && VanillaBackport.COMMON_CONFIG.hasLavaChickenMusicDisc.get()) {
             context.addPool(
                 LootPool.lootPool()
                     .add(LootItem.lootTableItem(ModItems.MUSIC_DISC_LAVA_CHICKEN.get()))


### PR DESCRIPTION
Same issue/fix as #261 but for 1.21.1