### PR TITLE
Fix SelectedItem NBT leaking to non-bundle items (#274)

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/common/api/bundle/BundleFeatures.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/api/bundle/BundleFeatures.java
@@ -108,6 +108,8 @@ public final class BundleFeatures {
     }
 
     public static void setSelectedItem(ItemStack bundle, int index) {
+        if (!bundle.is(ModItemTags.BUNDLES)) return;
+
         CompoundTag tag = bundle.getOrCreateTag();
         tag.putInt(TAG_SELECTED_ITEM, index);
     }
@@ -182,6 +184,8 @@ public final class BundleFeatures {
     }
 
     public static void toggleSelectedItem(ItemStack bundle, int index) {
+        if (!bundle.is(ModItemTags.BUNDLES)) return;
+
         CompoundTag tag = bundle.getOrCreateTag();
         int selected0 = tag.getInt(TAG_SELECTED_ITEM);
 

--- a/common/src/main/java/com/blackgear/vanillabackport/core/network/ServerboundSelectBundleItemPacket.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/core/network/ServerboundSelectBundleItemPacket.java
@@ -9,6 +9,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.BundleItem;
 import net.minecraft.world.item.ItemStack;
 
 public record ServerboundSelectBundleItemPacket(int slotId, int selectedItemIndex) implements Packet<ServerboundSelectBundleItemPacket> {
@@ -53,7 +54,9 @@ public record ServerboundSelectBundleItemPacket(int slotId, int selectedItemInde
 
                 if (slotId >= 0 && slotId < slots.size()) {
                     ItemStack stack = slots.get(slotId).getItem();
-                    BundleFeatures.toggleSelectedItem(stack, selectedItemIndex);
+                    if (stack.getItem() instanceof BundleItem) {
+                        BundleFeatures.toggleSelectedItem(stack, selectedItemIndex);
+                    }
                 }
             };
         }


### PR DESCRIPTION
Bug: Inventory sorting mods (e.g., Quark) could cause the SelectedItem NBT tag to leak from bundles to non-bundle items, making tthose items unstackable. Fixes #274 and #185.

Root cause: ServerboundSelectBundleItemPacket handler called toggleSelectedItem() on whatever item was in the target slot without checking it was a bundle. If an inventory sort moved the bundle between client packet send and server processing, a non-bundle item got the tag.

Fix: Added bundle type checks in setSelectedItem(), toggleSelectedItem(), and the packet handler.

Tested: Forge 1.20.1 with Quark — verified across multiple scenarios (empty/partial/full bundles, active selection + sorting, various item types). No NBT leakage observed.