### PR TITLE
Fieldguide variant support for cows, pigs, and chickens

### DIFF
--- a/common/src/main/resources/data/minecraft/fieldguide/variants/chicken.json
+++ b/common/src/main/resources/data/minecraft/fieldguide/variants/chicken.json
@@ -1,0 +1,22 @@
+{
+  "entries": [
+    {
+      "id": "minecraft:chicken",
+      "replace": false,
+      "variants": [
+        {
+          "id": "Temperant",
+          "nbt": "{variant: \"minecraft:temperate\"}"
+        },
+        {
+          "id": "Cold",
+          "nbt": "{variant: \"minecraft:cold\"}"
+        },
+        {
+          "id": "Warm",
+          "nbt": "{variant: \"minecraft:warm\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/minecraft/fieldguide/variants/cow.json
+++ b/common/src/main/resources/data/minecraft/fieldguide/variants/cow.json
@@ -1,0 +1,22 @@
+{
+  "entries": [
+    {
+      "id": "minecraft:cow",
+      "replace": false,
+      "variants": [
+        {
+          "id": "Temperant",
+          "nbt": "{variant: \"minecraft:temperate\"}"
+        },
+        {
+          "id": "Cold",
+          "nbt": "{variant: \"minecraft:cold\"}"
+        },
+        {
+          "id": "Warm",
+          "nbt": "{variant: \"minecraft:warm\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/minecraft/fieldguide/variants/pig.json
+++ b/common/src/main/resources/data/minecraft/fieldguide/variants/pig.json
@@ -1,0 +1,22 @@
+{
+  "entries": [
+    {
+      "id": "minecraft:pig",
+      "replace": false,
+      "variants": [
+        {
+          "id": "Temperant",
+          "nbt": "{variant: \"minecraft:temperate\"}"
+        },
+        {
+          "id": "Cold",
+          "nbt": "{variant: \"minecraft:cold\"}"
+        },
+        {
+          "id": "Warm",
+          "nbt": "{variant: \"minecraft:warm\"}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Instead of bothering both developers, i just decided to do pull requests. This adds field guide variant support for the warm, cold, and temperate variants of pigs, chickens, and cows created in 1.21.6.