### PR TITLE
fixed MobIntergration.register... beeing called too early resulting in NPE in forge 47.4.10

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/common/CommonSetup.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/CommonSetup.java
@@ -59,13 +59,13 @@ public class CommonSetup {
             event.register(VanillaBackport.resource("cat_variants"), new CatVariantReloadListener());
         });
 
-        MobIntegration.registerIntegrations(CommonSetup::mobIntegrations);
     }
 
     public static void asyncSetup(ParallelDispatch dispatch) {
         dispatch.enqueueWork(() -> {
             BiomeManager.add(WorldGeneration::bootstrap);
             BiomePlacement.registerBiomePlacements(BiomeGeneration::bootstrap);
+            MobIntegration.registerIntegrations(CommonSetup::mobIntegrations);
             BlockIntegration.registerIntegrations(CommonSetup::blockIntegrations);
             TradeIntegration.registerVillagerTrades(CommonSetup::tradeIntegrations);
             Parrot.MOB_SOUND_MAP.put(ModEntities.CREAKING.get(), ModSoundEvents.PARROT_IMITATE_CREAKING.get());

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ mod_id = vanillabackport
 # Dependencies
 fabric_loader_version = 0.16.10
 fabric_api_version = 0.92.1+1.20.1
-forge_version = 1.20.1-47.3.12
+forge_version = 1.20.1-47.4.10
 mixin_squared_version=0.1.1
 parchment_version = 2023.09.03
 terrablender_version = 1.20.1-3.0.1.7


### PR DESCRIPTION
Sadly this crash cannot be replicated in the dev environment but still appears in  the game itself.
Fixes #296 