### PR TITLE
set useLegacyMixinAp flag on loom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ subprojects {
 
     loom {
         silentMojangMappingsLicense()
+        mixin.useLegacyMixinAp = true
     }
 
     dependencies {


### PR DESCRIPTION
This is a potentially dirty fix for #309 

Newer versions of fabric and any version of neoforge do not require mixin refmaps anymore, but to my knowledge, at least the dev environment of forge still needs them. (for ForgeGradle 6).

This flag re-enables refmap generation, but might also do other things under the hood, that I could not yet see.