### PR TITLE
Fix registry validation crash on world load

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/core/mixin/common/BuildStateMixin.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/core/mixin/common/BuildStateMixin.java
@@ -1,0 +1,14 @@
+package com.blackgear.vanillabackport.core.mixin.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.core.RegistrySetBuilder$BuildState")
+public abstract class BuildStateMixin {
+    @Inject(method = "reportNotCollectedHolders", at = @At("HEAD"), cancellable = true)
+    private void vanillabackport$whitelistBackportedVanillaKeys(CallbackInfo ci) {
+        ci.cancel();
+    }
+}

--- a/common/src/main/resources/vanillabackport.mixins.json
+++ b/common/src/main/resources/vanillabackport.mixins.json
@@ -37,6 +37,7 @@
     "access.TextureSlotAccessor",
     "access.TreeDecoratorTypeAccessor",
     "access.WolfAccessor",
+    "common.BuildStateMixin",
     "common.ServerGamePacketListenerImplMixin",
     "common.blocks.BlockMixin",
     "common.blocks.CactusBlockMixin",


### PR DESCRIPTION
Minecraft past 1.20.5 performs a validation check in RegistrySetBuilder$BuildState which will throw an error when it finds unexpected vanilla namespace keys. This also will become a hard crash when mods like Patchouli, Ars Nouveau, and lithostitched are together.

This PR fixes this by just adding a mixin to cancel reportNotCollectedHolders.

I originally made [this PR](https://github.com/Apollounknowndev/lithostitched/pull/101) for lithostitched but it was (correctly) pointed out that it belongs here.