### PR TITLE
End flash compatibility with BadOptimizations 1.21.1

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/BadOptimizationsCommonHook.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/BadOptimizationsCommonHook.java
@@ -1,0 +1,22 @@
+package com.blackgear.vanillabackport.client.api.modules.end_flashes;
+
+import com.blackgear.vanillabackport.client.api.modules.end_flashes.EndFlashRenderer;
+// import com.mojang.logging.LogUtils;
+// import org.slf4j.Logger;
+import java.util.function.BooleanSupplier;
+
+public class BadOptimizationsCommonHook implements BooleanSupplier {
+    //private static final Logger LOGGER = LogUtils.getLogger();
+  // Class must have a public empty constructor!
+  public BadOptimizationsCommonHook() {}
+
+  // This method will be called up to once per tick
+  // If it returns true, the lightmap/skycolor will update immediately
+  @Override
+  public boolean getAsBoolean() {
+    // if (EndFlashRenderer.needsLightmapUpdate()){
+    //     LOGGER.info("Updating End Flash!");
+    // }
+    return (EndFlashRenderer.needsLightmapUpdate());
+  }
+}

--- a/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/EndFlashRenderer.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/EndFlashRenderer.java
@@ -21,14 +21,22 @@ import static com.mojang.blaze3d.platform.GlStateManager.*;
 public class EndFlashRenderer {
     private static final ResourceLocation END_FLASH_LOCATION = ResourceLocation.withDefaultNamespace("textures/environment/end_flash.png");
     private static final int END_SKY_COLOR = 0xFFCD60AC;
+    private static boolean endFlashNeedsUpdating = false;
+
+    public static boolean needsLightmapUpdate(){
+        return endFlashNeedsUpdating;
+    }
 
     public static void tick(Minecraft minecraft, ClientLevel level, EndFlashState state) {
+        endFlashNeedsUpdating = false;
         if (!VanillaBackport.CLIENT_CONFIG.endFlashSkyVisuals.get()) return;
         
         if (state == null) return;
 
         state.tick(level.getGameTime());
         
+        endFlashNeedsUpdating = state.isChangingIntensity();
+
         if (state.flashStartedThisTick() && !(minecraft.screen instanceof WinScreen)) {
             minecraft.getSoundManager().playDelayed(
                 new DirectionalSoundInstance(

--- a/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/EndFlashState.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/end_flashes/EndFlashState.java
@@ -59,6 +59,10 @@ public class EndFlashState {
         return Mth.lerp(partialTicks, this.oldIntensity, this.intensity);
     }
     
+    public boolean isChangingIntensity() {
+        return (this.oldIntensity!=this.intensity);
+    }
+
     public boolean flashStartedThisTick() {
         return this.intensity > 0.0F && this.oldIntensity <= 0.0F;
     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -41,5 +41,10 @@
     "minecraft": "~1.21.1",
     "java": ">=21",
     "fabric-api": "*"
+  },
+  "custom": {
+    "badoptimizations:cache_hooks": {
+      "common": "com.blackgear.vanillabackport.client.api.modules.end_flashes.BadOptimizationsCommonHook"
+    }
   }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -34,3 +34,6 @@ side = "BOTH"
 
 [[mixins]]
 config = "vanillabackport.mixins.json"
+
+["badoptimizations:cache_hooks"]
+common = "com.blackgear.vanillabackport.client.api.modules.end_flashes.BadOptimizationsCommonHook"


### PR DESCRIPTION
Added support for using the lightmap caching of BadOptimizations without breaking the end flash effect. Fabric is untested.
https://github.com/imthosea/BadOptimizations/wiki/Adding-lightmap-skycolor-caching-hooks