### PR TITLE
feat: Added Registering of Backported Blocks to Capabilities

### DIFF
--- a/neoforge/src/main/java/com/blackgear/vanillabackport/core/neoforge/ModEvents.java
+++ b/neoforge/src/main/java/com/blackgear/vanillabackport/core/neoforge/ModEvents.java
@@ -1,0 +1,40 @@
+package com.blackgear.vanillabackport.core.neoforge;
+
+import com.blackgear.vanillabackport.common.registries.blocks.ModBlockEntities;
+import com.blackgear.vanillabackport.common.registries.blocks.ModBlocks;
+import com.blackgear.vanillabackport.core.VanillaBackport;
+import net.minecraft.world.level.block.ChestBlock;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.items.wrapper.InvWrapper;
+
+import java.util.Objects;
+
+@EventBusSubscriber(modid = VanillaBackport.MOD_ID)
+public class ModEvents {
+  @SubscribeEvent
+  public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+    event.registerBlock(
+        Capabilities.ItemHandler.BLOCK,
+        (level, pos, state, blockEntity, direction) ->
+            new InvWrapper(Objects.requireNonNull(ChestBlock.getContainer((ChestBlock) state.getBlock(), state, level, pos, true))),
+        ModBlocks.COPPER_CHEST.get(),
+        ModBlocks.WAXED_COPPER_CHEST.get(),
+        ModBlocks.EXPOSED_COPPER_CHEST.get(),
+        ModBlocks.WAXED_EXPOSED_COPPER_CHEST.get(),
+        ModBlocks.WEATHERED_COPPER_CHEST.get(),
+        ModBlocks.WAXED_WEATHERED_COPPER_CHEST.get(),
+        ModBlocks.OXIDIZED_COPPER_CHEST.get(),
+        ModBlocks.WAXED_OXIDIZED_COPPER_CHEST.get()
+    );
+
+
+    event.registerBlockEntity(
+        Capabilities.ItemHandler.BLOCK,
+        ModBlockEntities.SHELF.get(),
+        (container, side) -> new InvWrapper(container)
+    );
+  }
+}


### PR DESCRIPTION
This adds the correct registering of capabilities of the copper chests and shelfs.
This should make them compatible with mods that use "capabilities" to do item stuff, like the create mod.

I think capabilities were already a thing in 1.20 forge but I am unsure.

https://github.com/user-attachments/assets/a08cdd09-6c52-4a46-acd9-87194c542422

