### PR TITLE
Fix golem container detection for MCV compat

### DIFF
--- a/common/src/main/generated/data/minecraft/tags/block/copper_golem_destination_targets.json
+++ b/common/src/main/generated/data/minecraft/tags/block/copper_golem_destination_targets.json
@@ -2,6 +2,30 @@
   "values": [
     "minecraft:chest",
     "minecraft:trapped_chest",
-    "minecraft:barrel"
+    "minecraft:barrel",
+    "lolmcv:oak_chest",
+    "lolmcv:spruce_chest",
+    "lolmcv:birch_chest",
+    "lolmcv:jungle_chest",
+    "lolmcv:acacia_chest",
+    "lolmcv:dark_oak_chest",
+    "lolmcv:mangrove_chest",
+    "lolmcv:cherry_chest",
+    "lolmcv:pale_oak_chest",
+    "lolmcv:bamboo_chest",
+    "lolmcv:crimson_chest",
+    "lolmcv:warped_chest",
+    "lolmcv:oak_trapped_chest",
+    "lolmcv:spruce_trapped_chest",
+    "lolmcv:birch_trapped_chest",
+    "lolmcv:jungle_trapped_chest",
+    "lolmcv:acacia_trapped_chest",
+    "lolmcv:dark_oak_trapped_chest",
+    "lolmcv:mangrove_trapped_chest",
+    "lolmcv:cherry_trapped_chest",
+    "lolmcv:pale_oak_trapped_chest",
+    "lolmcv:bamboo_trapped_chest",
+    "lolmcv:crimson_trapped_chest",
+    "lolmcv:warped_trapped_chest"
   ]
 }

--- a/common/src/main/generated/data/minecraft/tags/block/copper_golem_destination_targets.json
+++ b/common/src/main/generated/data/minecraft/tags/block/copper_golem_destination_targets.json
@@ -3,29 +3,9 @@
     "minecraft:chest",
     "minecraft:trapped_chest",
     "minecraft:barrel",
-    "lolmcv:oak_chest",
-    "lolmcv:spruce_chest",
-    "lolmcv:birch_chest",
-    "lolmcv:jungle_chest",
-    "lolmcv:acacia_chest",
-    "lolmcv:dark_oak_chest",
-    "lolmcv:mangrove_chest",
-    "lolmcv:cherry_chest",
-    "lolmcv:pale_oak_chest",
-    "lolmcv:bamboo_chest",
-    "lolmcv:crimson_chest",
-    "lolmcv:warped_chest",
-    "lolmcv:oak_trapped_chest",
-    "lolmcv:spruce_trapped_chest",
-    "lolmcv:birch_trapped_chest",
-    "lolmcv:jungle_trapped_chest",
-    "lolmcv:acacia_trapped_chest",
-    "lolmcv:dark_oak_trapped_chest",
-    "lolmcv:mangrove_trapped_chest",
-    "lolmcv:cherry_trapped_chest",
-    "lolmcv:pale_oak_trapped_chest",
-    "lolmcv:bamboo_trapped_chest",
-    "lolmcv:crimson_trapped_chest",
-    "lolmcv:warped_trapped_chest"
+    {
+     "id": "#lieonstudios:chests/wooden",
+     "required": false
+    }
   ]
 }

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/mob/animal/golem/copper_golem/TransportItemsBetweenContainers.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/mob/animal/golem/copper_golem/TransportItemsBetweenContainers.java
@@ -272,7 +272,7 @@ public class TransportItemsBetweenContainers extends Behavior<PathfinderMob> {
             LevelChunk levelChunk = level.getChunkSource().getChunkNow(chunkPos.x, chunkPos.z);
             if (levelChunk != null) {
                 for (BlockEntity potentialTarget : levelChunk.getBlockEntities().values()) {
-                    if (potentialTarget instanceof ChestBlockEntity || potentialTarget instanceof BarrelBlockEntity) {
+                    if (potentialTarget instanceof Container) {
                         double distance = potentialTarget.getBlockPos().distToCenterSqr(entity.position());
                         if (distance < closestDistance) {
                             TransportItemTarget targetValidToPick = this.isTargetValidToPick(entity, level, potentialTarget, visitedPositions, unreachablePositions, targetBlockSearchArea);


### PR DESCRIPTION
Changed detection from Barrel and Chest to Container
Added MCV Chests as tag (wooden) to copper_golem_destination_targets.json

(MCV = More Chest Variants)