### PR TITLE
Vanilla Fixes for Cushions 1.21

### DIFF
--- a/common/src/main/generated/data/minecraft/tags/block/cushion_uses_collision_shape.json
+++ b/common/src/main/generated/data/minecraft/tags/block/cushion_uses_collision_shape.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#minecraft:cauldrons",
+    "minecraft:hopper",
+    "minecraft:composter"
+  ]
+}

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
@@ -3,6 +3,7 @@ package com.blackgear.vanillabackport.common.level.entity.decoration;
 import com.blackgear.vanillabackport.client.registries.ModSoundEvents;
 import com.blackgear.vanillabackport.common.registries.entities.ModEntityDataSerializers;
 import com.blackgear.vanillabackport.common.registries.items.ModItems;
+import com.blackgear.vanillabackport.core.util.Utilities;
 import com.blackgear.vanillabackport.core.util.Utilities.CollisionUtils;
 import com.blackgear.vanillabackport.core.util.Utilities.PositionUtils;
 import net.minecraft.core.BlockPos;
@@ -14,6 +15,7 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.AbortableIterationConsumer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
@@ -31,6 +33,8 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
@@ -115,10 +119,28 @@ public class Cushion extends BlockAttachedEntity {
             );
         }
     }
-    
-    public static boolean wouldSurviveAt(Level level, AABB box) {
+
+    public static boolean canBePlacedAt(final Level level, final AABB boundingBox) {
+        return wouldSurviveAt(level, boundingBox) && !isAnchorBuried(level, boundingBox);
+    }
+
+    public static boolean wouldSurviveAt(final Level level, final AABB boundingBox) {
+        return hasAnchorBelow(level, boundingBox) && !isCoveredBySuffocatingBlocks(level, boundingBox);
+    }
+
+    private static boolean isCoveredBySuffocatingBlocks(final Level level, final AABB boundingBox) {
+        for (BlockPos blockPos : PositionUtils.betweenClosed(CollisionUtils.nextDeflated(boundingBox))) {
+            if (!level.getBlockState(blockPos).isSuffocating(level, blockPos)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean hasAnchorBelow(Level level, AABB box) {
         AABB anchorBox = new AABB(box.minX, box.minY - 0.015625, box.minZ, Math.nextDown(box.maxX), box.minY, Math.nextDown(box.maxZ));
-        
+
         for (BlockPos pos : PositionUtils.betweenClosed(anchorBox)) {
             BlockState state = level.getBlockState(pos);
             VoxelShape shape = state.getShape(level, pos);
@@ -126,23 +148,28 @@ public class Cushion extends BlockAttachedEntity {
                 return true;
             }
         }
-        
+
+        return false;
+    }
+
+    private static boolean isAnchorBuried(final Level level, final AABB boundingBox) {
+        AABB restingSlice = CollisionUtils.nextDeflated(
+            new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.minY + 0.015625, boundingBox.maxZ)
+        );
+        VoxelShape exposedSurface = Shapes.create(restingSlice);
+
+        for (VoxelShape collider : level.getBlockCollisions(null, restingSlice)) {
+            exposedSurface = Shapes.join(exposedSurface, collider, BooleanOp.ONLY_FIRST);
+            if (exposedSurface.isEmpty()) {
+                return true;
+            }
+        }
         return false;
     }
     
     @Override
     public boolean survives() {
-        Level level = this.level();
-        AABB box = this.getBoundingBox();
-        if (!wouldSurviveAt(level, box)) return false;
-        
-        for (BlockPos pos : PositionUtils.betweenClosed(CollisionUtils.nextDeflated(box))) {
-            if (!level.getBlockState(pos).isCollisionShapeFullBlock(level, pos)) {
-                return true;
-            }
-        }
-        
-        return false;
+        return wouldSurviveAt(this.level(), this.getBoundingBox());
     }
 
     @Override
@@ -158,7 +185,7 @@ public class Cushion extends BlockAttachedEntity {
         if (this.isRemoved()) return;
 
         boolean isInFire = level
-            .getBlockStates(getBoundingBox())
+            .getBlockStates(CollisionUtils.nextDeflated(getBoundingBox()))
             .anyMatch(blockState -> blockState.is(BlockTags.FIRE));
 
         if (isInFire) hurt(damageSources().inFire(), 1.0f);

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
@@ -6,6 +6,7 @@ import com.blackgear.vanillabackport.common.registries.items.ModItems;
 import com.blackgear.vanillabackport.core.util.Utilities.CollisionUtils;
 import com.blackgear.vanillabackport.core.util.Utilities.PositionUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -57,7 +58,9 @@ public class Cushion extends BlockAttachedEntity {
         this.showBreakingParticles();
         if (this.level() instanceof ServerLevel level && level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
             if (!(entity instanceof Player player && player.hasInfiniteMaterials())) {
-                this.spawnAtLocation(Cushion.getByColor(this.getColor()).cushion());
+                ItemStack cushion = new ItemStack(Cushion.getByColor(this.getColor()).cushion());
+                cushion.set(DataComponents.CUSTOM_NAME, this.getCustomName());
+                this.spawnAtLocation(cushion);
             }
         }
     }

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
@@ -16,6 +16,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.decoration.BlockAttachedEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeColor;
@@ -138,7 +139,15 @@ public class Cushion extends BlockAttachedEntity {
         
         return false;
     }
-    
+
+    @Override
+    public void thunderHit(ServerLevel level, LightningBolt lightning) {
+        if (!this.isRemoved()) {
+            this.kill();
+            this.dropItem(null);
+        }
+    }
+
     @Override
     protected void recalculateBoundingBox() {
         this.setBoundingBox(this.makeBoundingBox());

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
@@ -142,6 +143,25 @@ public class Cushion extends BlockAttachedEntity {
         }
         
         return false;
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+
+        if (level() instanceof ServerLevel serverLevel) {
+            destroyIfInFire(serverLevel);
+        }
+    }
+
+    public void destroyIfInFire(ServerLevel level) {
+        if (this.isRemoved()) return;
+
+        boolean isInFire = level
+            .getBlockStates(getBoundingBox())
+            .anyMatch(blockState -> blockState.is(BlockTags.FIRE));
+
+        if (isInFire) hurt(damageSources().inFire(), 1.0f);
     }
 
     @Override

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/entity/decoration/Cushion.java
@@ -15,6 +15,7 @@ import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LightningBolt;
@@ -149,6 +150,20 @@ public class Cushion extends BlockAttachedEntity {
             this.kill();
             this.dropItem(null);
         }
+    }
+
+    @Override
+    public boolean hurt(DamageSource source, float amount) {
+        return !isBreakingDeniedFor(source) && super.hurt(source, amount);
+    }
+
+    private boolean isBreakingDeniedFor(final DamageSource source) {
+        if (!(source.getEntity() instanceof Player player)) return false;
+
+        boolean deniedBecauseEntity = !player.mayBuild();
+        boolean deniedBecauseLevel = !this.level().mayInteract(player, this.pos);
+
+        return deniedBecauseEntity || deniedBecauseLevel;
     }
 
     @Override

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/item/CushionItem.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/item/CushionItem.java
@@ -54,6 +54,7 @@ public class CushionItem extends Item {
             cushion.moveTo(entityPos, Direction.fromYRot(placeContext.getRotation()).toYRot(), 0.0F);
             cushion.setColor(this.color);
             server.addFreshEntity(cushion);
+            cushion.destroyIfInFire(server);
             level.playSound(null, cushion.getX(), cushion.getY(), cushion.getZ(), ModSoundEvents.CUSHION_PLACE.get(), SoundSource.BLOCKS, 0.75F, 0.8F);
             cushion.gameEvent(GameEvent.ENTITY_PLACE);
             stack.consume(1, placeContext.getPlayer());

--- a/common/src/main/java/com/blackgear/vanillabackport/common/level/item/CushionItem.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/common/level/item/CushionItem.java
@@ -3,6 +3,7 @@ package com.blackgear.vanillabackport.common.level.item;
 import com.blackgear.vanillabackport.client.registries.ModSoundEvents;
 import com.blackgear.vanillabackport.common.level.entity.decoration.Cushion;
 import com.blackgear.vanillabackport.common.registries.entities.ModEntityTypes;
+import com.blackgear.vanillabackport.core.data.tags.ModBlockTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -10,14 +11,17 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.function.Consumer;
@@ -32,16 +36,17 @@ public class CushionItem extends Item {
     
     @Override
     public InteractionResult useOn(UseOnContext context) {
-        Direction clickedFace = context.getClickedFace();
+        UseOnContext recalculatedContext = recalculateContextForSpecialCollisionShapes(context);
+        Direction clickedFace = recalculatedContext.getClickedFace();
         if (clickedFace != Direction.UP) return InteractionResult.FAIL;
         
         Level level = context.getLevel();
-        BlockPlaceContext placeContext = new BlockPlaceContext(context);
+        BlockPlaceContext placeContext = new BlockPlaceContext(recalculatedContext);
         BlockPos pos = placeContext.getClickedPos();
-        Vec3 entityPos = new Vec3(pos.getX() + 0.5, context.getClickLocation().y, pos.getZ() + 0.5);
+        Vec3 entityPos = new Vec3(pos.getX() + 0.5, recalculatedContext.getClickLocation().y, pos.getZ() + 0.5);
         AABB spawnAABB = ModEntityTypes.CUSHION.get().getSpawnAABB(entityPos.x, entityPos.y, entityPos.z);
         
-        if (!Cushion.wouldSurviveAt(level, spawnAABB)) return InteractionResult.FAIL;
+        if (!Cushion.canBePlacedAt(level, spawnAABB)) return InteractionResult.FAIL;
         
         ItemStack stack = context.getItemInHand();
         if (level instanceof ServerLevel server) {
@@ -56,10 +61,30 @@ public class CushionItem extends Item {
             server.addFreshEntity(cushion);
             cushion.destroyIfInFire(server);
             level.playSound(null, cushion.getX(), cushion.getY(), cushion.getZ(), ModSoundEvents.CUSHION_PLACE.get(), SoundSource.BLOCKS, 0.75F, 0.8F);
-            cushion.gameEvent(GameEvent.ENTITY_PLACE);
+            cushion.gameEvent(GameEvent.ENTITY_PLACE, context.getPlayer());
             stack.consume(1, placeContext.getPlayer());
         }
         
         return InteractionResult.SUCCESS;
+    }
+
+    private static UseOnContext recalculateContextForSpecialCollisionShapes(final UseOnContext context) {
+        Player player = context.getPlayer();
+        if (player == null) {
+            return context;
+        } else {
+            Level level = context.getLevel();
+            BlockPos clickedPos = context.getClickedPos();
+            BlockState clickedState = level.getBlockState(clickedPos);
+            if (!clickedState.is(ModBlockTags.CUSHION_USES_COLLISION_SHAPE)) {
+                return context;
+            } else {
+                Vec3 rayFrom = player.getEyePosition();
+                Vec3 ray = context.getClickLocation().subtract(rayFrom);
+                Vec3 rayTo = context.getClickLocation().add(ray.normalize().scale(0.001));
+                BlockHitResult collisionHitResult = clickedState.getCollisionShape(level, clickedPos).clip(rayFrom, rayTo, clickedPos);
+                return collisionHitResult == null ? context : new UseOnContext(player, context.getHand(), collisionHitResult);
+            }
+        }
     }
 }

--- a/common/src/main/java/com/blackgear/vanillabackport/core/data/tags/ModBlockTags.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/core/data/tags/ModBlockTags.java
@@ -47,4 +47,6 @@ public class ModBlockTags {
     
     public static final TagKey<Block> WOOL_STAIRS = TAGS.register("wool_stairs");
     public static final TagKey<Block> WOOL_SLABS = TAGS.register("wool_slabs");
+
+    public static final TagKey<Block> CUSHION_USES_COLLISION_SHAPE = TAGS.register("cushion_uses_collision_shape");
 }

--- a/fabric/src/main/java/com/blackgear/vanillabackport/data/server/tags/BlockTagGenerator.java
+++ b/fabric/src/main/java/com/blackgear/vanillabackport/data/server/tags/BlockTagGenerator.java
@@ -229,6 +229,11 @@ public class BlockTagGenerator extends FabricTagProvider.BlockTagProvider {
             .add(Blocks.CHEST)
             .add(Blocks.TRAPPED_CHEST)
             .add(Blocks.BARREL);
+
+        this.getOrCreateTagBuilder(ModBlockTags.CUSHION_USES_COLLISION_SHAPE)
+            .forceAddTag(BlockTags.CAULDRONS)
+            .add(Blocks.HOPPER)
+            .add(Blocks.COMPOSTER);
     }
 
     protected DualTagHolder getDualTagBuilder(TagKey<Block> forge, TagKey<Block> fabric) {


### PR DESCRIPTION
This MR includes Fixes and Changes that have been made to the cushions in the vanilla game over the past few snapshots.

It includes:
- Cushions can no longer be placed at any height inside of cauldrons, composters and hoppers
- Cushions are now only destroyed when fully covered by blocks that cause suffocation
- Cushions get hurt by fire
- Cushions can no longer be broken in adventure mode, in spawn protection and outside world borders
- Cushions break when hit by lightning
- Cushions keep their custom name when broken

I will also open up a MR for 1.20.1 in a second including the same changes.
If any questions come up, just ask