### PR TITLE
Endless Bundle UI 1.21.1

### DIFF
--- a/common/src/main/java/com/blackgear/vanillabackport/client/ClientConfig.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/ClientConfig.java
@@ -13,6 +13,9 @@ public class ClientConfig {
     public final ConfigBuilder.ConfigValue<Boolean> endFlashSkyVisuals;
     public final ConfigBuilder.ConfigValue<Boolean> endFlashTerrainVisuals;
 
+    // Enhancements
+    public final ConfigBuilder.ConfigValue<Boolean> endlessBundleUi;
+
     public ClientConfig(ConfigBuilder builder) {
         builder.push("Spring to Life");
         this.hasFallingLeaves = builder.comment("allow falling leaves particles to generate")
@@ -30,6 +33,11 @@ public class ClientConfig {
             .define("end_flash_sky_visuals", true);
         this.endFlashTerrainVisuals = builder.comment("toggle the end flash terrain visuals")
             .define("end_flash_terrain_visuals", true);
+        builder.pop();
+
+        builder.push("Enhancements");
+        this.endlessBundleUi = builder.comment("makes all items in a bundle accessible not only the first 12")
+            .define("endless_bundle_ui", false);
         builder.pop();
     }
 }

--- a/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/bundle_ui/BundleTooltipHandler.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/bundle_ui/BundleTooltipHandler.java
@@ -2,6 +2,7 @@ package com.blackgear.vanillabackport.client.api.modules.bundle_ui;
 
 import com.blackgear.vanillabackport.common.api.modules.bundle_ui.BundleFeatures;
 import com.blackgear.vanillabackport.common.api.modules.bundle_ui.ModernBundle;
+import com.blackgear.vanillabackport.core.VanillaBackport;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
@@ -52,8 +53,8 @@ public class BundleTooltipHandler {
         return this.contents.isEmpty() ? 39 : this.backgroundHeight();
     }
     
-    public int getWidth(Font font) {
-        return 96;
+    public int getWidth() {
+        return gridSizeX() * 24;
     }
     
     private int backgroundHeight() {
@@ -65,24 +66,32 @@ public class BundleTooltipHandler {
     }
     
     private int getContentXOffset(int width) {
-        return (width - 96) / 2;
+        return (width - getWidth()) / 2;
     }
-    
+
+    private int gridSizeX() {
+        return VanillaBackport.CLIENT_CONFIG.endlessBundleUi.get()
+            ? Math.max(4, Mth.ceil(Math.sqrt(this.contents.size())))
+            : 4;
+    }
+
     private int gridSizeY() {
-        return Mth.positiveCeilDiv(this.slotCount(), 4);
+        return Mth.positiveCeilDiv(this.slotCount(), gridSizeX());
     }
     
     private int slotCount() {
-        return Math.min(12, this.contents.size());
+        return VanillaBackport.CLIENT_CONFIG.endlessBundleUi.get()
+            ? this.contents.size()
+            : Math.min(12, this.contents.size());
     }
     
     public boolean renderImage(Font font, int x, int y, GuiGraphics graphics) {
         if (!BundleFeatures.onBundleUpdate()) return false;
         
         if (this.contents.isEmpty()) {
-            this.renderEmptyBundleTooltip(font, x, y, this.getWidth(font), graphics);
+            this.renderEmptyBundleTooltip(font, x, y, this.getWidth(), graphics);
         } else {
-            this.renderBundleWithItemsTooltip(font, x, y, this.getWidth(font), graphics);
+            this.renderBundleWithItemsTooltip(font, x, y, this.getWidth(), graphics);
         }
         
         return true;
@@ -96,12 +105,12 @@ public class BundleTooltipHandler {
     private void renderBundleWithItemsTooltip(Font font, int x, int y, int width, GuiGraphics graphics) {
         boolean maxDisplay = this.contents.size() > 12;
         List<ItemStack> stacks = this.getShownItems(((ModernBundle) (Object) this.contents).getNumberOfItemsToShow());
-        int xOffset = x + this.getContentXOffset(width) + 96;
+        int xOffset = x + this.getContentXOffset(width) + getWidth();
         int yOffset = y + this.gridSizeY() * 24;
         int index = 1;
         
         for (int row = 1; row <= this.gridSizeY(); row++) {
-            for (int column = 1; column <= 4; column++) {
+            for (int column = 1; column <= gridSizeX(); column++) {
                 int slotX = xOffset - column * 24;
                 int slotY = yOffset - row * 24;
                 
@@ -124,7 +133,7 @@ public class BundleTooltipHandler {
     }
     
     private boolean shouldRenderSurplusText(boolean maxDisplay, int column, int row) {
-        return maxDisplay && column * row == 1;
+        return !VanillaBackport.CLIENT_CONFIG.endlessBundleUi.get() && (maxDisplay && column * row == 1);
     }
     
     private boolean shouldRenderItemSlot(List<ItemStack> items, int itemIndex) {
@@ -180,24 +189,24 @@ public class BundleTooltipHandler {
     
     private void drawProgressBar(int x, int y, Font textRenderer, GuiGraphics graphics) {
         graphics.blitSprite(this.getProgressBarTexture(), x + 1, y, this.getProgressBarFill(), 13);
-        graphics.blitSprite(PROGRESSBAR_BORDER_SPRITE, x, y, 96, 13);
+        graphics.blitSprite(PROGRESSBAR_BORDER_SPRITE, x, y, getWidth(), 13);
         
         Component component = this.getProgressBarFillText();
         if (component != null) {
-            graphics.drawCenteredString(textRenderer, component, x + 48, y + 3, -1);
+            graphics.drawCenteredString(textRenderer, component, x + (getWidth() / 2), y + 3, -1);
         }
     }
     
     private void drawEmptyBundleDescriptionText(int x, int y, Font font, GuiGraphics graphics) {
-        graphics.drawWordWrap(font, BUNDLE_EMPTY_DESCRIPTION, x, y, 96, -5592406);
+        graphics.drawWordWrap(font, BUNDLE_EMPTY_DESCRIPTION, x, y, getWidth(), -5592406);
     }
     
     private int getEmptyBundleDescriptionTextHeight(Font font) {
-        return font.split(BUNDLE_EMPTY_DESCRIPTION, 96).size() * 9;
+        return font.split(BUNDLE_EMPTY_DESCRIPTION, getWidth()).size() * 9;
     }
     
     private int getProgressBarFill() {
-        return Mth.clamp(Mth.mulAndTruncate(this.contents.weight(), 94), 0, 94);
+        return Mth.clamp(Mth.mulAndTruncate(this.contents.weight(), getWidth() - 2), 0, getWidth() - 2);
     }
     
     private ResourceLocation getProgressBarTexture() {

--- a/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/bundle_ui/ScrollWheelHandler.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/client/api/modules/bundle_ui/ScrollWheelHandler.java
@@ -25,7 +25,18 @@ public class ScrollWheelHandler {
 
     public static int getNextScrollWheelSelection(double delta, int index, int max) {
         int direction = (int) Math.signum(delta);
-        index -= direction;
+
+        /*
+        When scrolling backwards as the first selection it should not subtract from the index
+        because it is already the correct value: -1
+
+        Initial Scroll when: index = 1
+        Backwards Scroll when: direction -1
+         */
+        if (!(index == -1 && direction == 1)) {
+            index -= direction;
+        }
+
         return (index % max + max) % max;
     }
 }

--- a/common/src/main/java/com/blackgear/vanillabackport/core/mixin/client/bundle_ui/ClientBundleTooltipMixin.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/core/mixin/client/bundle_ui/ClientBundleTooltipMixin.java
@@ -32,7 +32,7 @@ public abstract class ClientBundleTooltipMixin implements ClientTooltipComponent
 
     @Override
     public int getWidth(Font font) {
-        return this.vb$handler.getWidth(font);
+        return this.vb$handler.getWidth();
     }
 
     @Inject(method = "renderImage", at = @At("HEAD"), cancellable = true)

--- a/common/src/main/java/com/blackgear/vanillabackport/core/mixin/common/bundle_ui/BundleContentsMixin.java
+++ b/common/src/main/java/com/blackgear/vanillabackport/core/mixin/common/bundle_ui/BundleContentsMixin.java
@@ -1,6 +1,7 @@
 package com.blackgear.vanillabackport.core.mixin.common.bundle_ui;
 
 import com.blackgear.vanillabackport.common.api.modules.bundle_ui.ModernBundle;
+import com.blackgear.vanillabackport.core.VanillaBackport;
 import net.minecraft.world.item.component.BundleContents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -25,6 +26,10 @@ public abstract class BundleContentsMixin implements ModernBundle {
     @Override
     public int getNumberOfItemsToShow() {
         int contents = this.size();
+        if (VanillaBackport.CLIENT_CONFIG.endlessBundleUi.get()) {
+            return contents;
+        }
+
         int maxDisplay = contents > 12 ? 11 : 12;
         int remainder = contents % 4;
         int padding = remainder == 0 ? 0 : 4 - remainder;


### PR DESCRIPTION
Hello,

This PR adds the "Endless Bundle UI" config option that makes all items (instead of only the first 12) inside a bundle visible and accessible. It is inspired by the [Bundles Beyond](https://modrinth.com/mod/bundles-beyond) mod and is by default off.

I don't know how you handled the Locator Bar Configs so I just put this option here in a category called "Enhancements". I would adjust it once I know how you handled them.

1.20 port coming in a sec


Endless Bundle UI off:
<img width="287" height="265" alt="Bildschirmfoto vom 2026-09-04 14-19-47" src="https://github.com/user-attachments/assets/30cd5d70-befb-4779-b5d8-b9fbaa5cb7b4" />


Endless Bundle UI on:
<img width="464" height="482" alt="Bildschirmfoto vom 2026-09-04 14-20-08" src="https://github.com/user-attachments/assets/2e7014c8-2125-4733-9c21-c001037597c1" />
